### PR TITLE
fix: disable self signed jwt if users provide their own credential

### DIFF
--- a/google/cloud/channel_v1/services/cloud_channel_service/client.py
+++ b/google/cloud/channel_v1/services/cloud_channel_service/client.py
@@ -427,7 +427,8 @@ class CloudChannelServiceClient(metaclass=CloudChannelServiceClientMeta):
                 client_cert_source_for_mtls=client_cert_source_func,
                 quota_project_id=client_options.quota_project_id,
                 client_info=client_info,
-                always_use_jwt_access= not credentials and (
+                always_use_jwt_access=not credentials
+                and (
                     Transport == type(self).get_transport_class("grpc")
                     or Transport == type(self).get_transport_class("grpc_asyncio")
                 ),

--- a/google/cloud/channel_v1/services/cloud_channel_service/client.py
+++ b/google/cloud/channel_v1/services/cloud_channel_service/client.py
@@ -427,7 +427,7 @@ class CloudChannelServiceClient(metaclass=CloudChannelServiceClientMeta):
                 client_cert_source_for_mtls=client_cert_source_func,
                 quota_project_id=client_options.quota_project_id,
                 client_info=client_info,
-                always_use_jwt_access=(
+                always_use_jwt_access= not credentials and (
                     Transport == type(self).get_transport_class("grpc")
                     or Transport == type(self).get_transport_class("grpc_asyncio")
                 ),

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "extends": [
-    "config:base",  ":preserveSemverRanges"
+    "config:base",
+    ":preserveSemverRanges",
+    ":disableDependencyDashboard"
   ],
   "ignorePaths": [".pre-commit-config.yaml"],
   "pip_requirements": {

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,6 @@
 {
   "extends": [
-    "config:base",
-    ":preserveSemverRanges",
-    ":disableDependencyDashboard"
+    "config:base",  ":preserveSemverRanges"
   ],
   "ignorePaths": [".pre-commit-config.yaml"],
   "pip_requirements": {


### PR DESCRIPTION
Self signed jwt doesn't work for non-prod endpoint, and the workaround is let the customer pass in their own credential to disable self signed jwt, see https://github.com/googleapis/python-aiplatform/issues/553#issuecomment-887124490. However the workaround doesn't work as expected, and this PR fixes the issue. 

related [PR](https://github.com/googleapis/gapic-generator-python/pull/983) in gapic-generator-python.

fixes b/197117709
