### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ order management, billing management, policy and authorization management, and c
 - `Product Documentation`_
 
 .. |GA| image:: https://img.shields.io/badge/support-ga-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-channel.svg
    :target: https://pypi.org/project/google-cloud-channel/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-channel.svg
@@ -81,4 +81,4 @@ Next Steps
    APIs that we cover.
 
 .. _Cloud Channel API Product documentation:  https://cloud.google.com/channel/docs
-.. _README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.