### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "cloudchannel",
     "name_pretty": "Channel Services",
     "product_documentation": "https://cloud.google.com/channel/",
-    "client_documentation": "https://googleapis.dev/python/cloudchannel/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudchannel/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ order management, billing management, policy and authorization management, and c
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-channel.svg
    :target: https://pypi.org/project/google-cloud-channel/
 .. _Cloud Channel API: https://cloud.google.com/channel/docs
-.. _Client Library Documentation: https://googleapis.dev/python/cloudchannel/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/cloudchannel/latest
 .. _Product Documentation:  https://cloud.google.com/channel/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.